### PR TITLE
Add ability to describe commit types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "git-semantic-commit",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
             "test"
           ],
           "items": {
-            "type": "string"
+            "type": ["string", "object"],
+            "description": "Can be either a string, or an object. If an object, use type for the commit type, and description to give a short description for the particular commit type."
           },
           "minItems": 1,
           "uniqueItems": true,

--- a/src/commands/semantic-commit.ts
+++ b/src/commands/semantic-commit.ts
@@ -17,7 +17,7 @@ export class SemanticCommitCommand extends Command {
 
   context: ExtensionContext;
   scope: string;
-  types: string[];
+  types: (string | {type: string, description: string})[];
 
   constructor(context: ExtensionContext) {
     super();
@@ -110,13 +110,17 @@ export class SemanticCommitCommand extends Command {
 
   private createQuickPickItems(): QuickPickItem[] {
     const hasScope = this.hasScope();
-    const typeItems = this.types.map(type => ({
-      label: `$(git-commit) Commit with "${type}" type`,
-      alwaysShow: true,
-      actionType: ActionType.subject,
-      type,
-      description: ''
-    }));
+    const typeItems = this.types.map(item => {
+        const description = typeof item === "string" ? "" : item.description
+        const type = typeof item === "string" ? item : item.type
+        return ({
+          label: `$(git-commit) Commit with "${type}" type`,
+          alwaysShow: true,
+          actionType: ActionType.subject,
+          type,
+          description
+        })
+    });
 
     return [
       {


### PR DESCRIPTION
This is a non-breaking change, fully optional, and works alongside existing configs. (Eg.: You can mix and match `string`s and `object` of form `{type: string, description: string}`)

Example in `.vscode/settings.json`:

```json
{ 
  "gitSemanticCommit.types": [
    {"type": "feat", "description": "A new feature"}
  ]
}
```

![image](https://user-images.githubusercontent.com/18369201/73666934-d8d9fe00-46a3-11ea-8206-eea54d72cc97.png)
