### PR TITLE
Install dependencies in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ install:
       export DISPLAY=':99.0'
       /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     fi
+  - npm install
 script:
   - npm test


### PR DESCRIPTION
Looks like my PR #11 failed, because `sh: 1: tsc: not found`. I suggest running `npm install` before `npm test` is called.


Strangely, this PR passed... :thinking: 