### PR TITLE
Improve integration tests

### DIFF
--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -1,4 +1,4 @@
-mkdir test-temp
+mkdir -p test-temp
 
 cd test-temp
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -5,7 +5,7 @@ async function main() {
   try {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../');
     const extensionTestsPath = path.resolve(__dirname, './suite/index');
-    const testWorkspace = path.resolve(__dirname, './test-temp');
+    const testWorkspace = path.resolve(__dirname, '../../test-temp');
 
     await runTests({
       extensionDevelopmentPath,


### PR DESCRIPTION
I noticed running the tests locally that the two .txt files get added to the main repo incorrectly, which messes with the repo.

With this fix, the VS Code window opens in the temp directory and commits are made there. You can see this in the directory name of the open window.

As an extra fix, I added `mkdir -p` flag for pretest so it does not log an error if the directory exists.